### PR TITLE
PPYZ-280: SMSes in django admin - 504 error 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+### 3.1.3
+- Added requirement `django-admin-rangefilter==0.13.2`
+- Added sent date range filter to SMSAdmin's list filter
+- Removed date_hierarchy from SMSAdmin
+- Fix missing quote in `smsgateway/backends/kpnbe.py`
+
 ### 3.1.2
 
 - Added configurable Redis expiration timeouts for incoming/outgoing messages.
@@ -15,6 +21,7 @@
 How to install:
 
 * Add 'smsgateway' to your INSTALLED_APPS
+* Add 'rangefilter' to your INSTALLED_APPS due to changes in `3.1.3` version
 * Configure it:
 
     # settings.py

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         'django-db-locking>=2.2,<2.3',
         'phonenumberslite==8.12.9',
         'celery<5',
+        'django-admin-rangefilter==0.13.2',
     ],
     setup_requires=['pytest-runner', ],
     dependency_links=[],

--- a/smsgateway/__init__.py
+++ b/smsgateway/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '3.1.2'
+__version__ = '3.1.3'
 
 
 def get_account(using=None):

--- a/smsgateway/admin.py
+++ b/smsgateway/admin.py
@@ -1,13 +1,18 @@
 from django.contrib import admin
+from rangefilter.filters import DateRangeFilterBuilder
 
 from smsgateway.models import SMS, QueuedSMS
 
 
 class SMSAdmin(admin.ModelAdmin):
-    date_hierarchy = 'sent'
     list_display = ('direction', 'sent', 'sender', 'to', 'content', 'operator', 'backend', 'gateway', 'gateway_ref')
     search_fields = ('sender', 'to', 'content',)
-    list_filter = ('operator', 'direction', 'gateway', 'backend')
+    list_filter = (
+        (
+            "sent", DateRangeFilterBuilder(title="By Sent date"),
+        ),
+        'operator', 'direction', 'gateway', 'backend',
+    )
 
 
 admin.site.register(SMS, SMSAdmin)

--- a/smsgateway/backends/kpnbe.py
+++ b/smsgateway/backends/kpnbe.py
@@ -31,7 +31,7 @@ class KPNBEBackend(SMSBackend):
 
         # Encode message
         msg = sms_request.msg
-        msg = msg.replace('€', EUR')
+        msg = msg.replace('€', 'EUR')
         try:
             msg = msg.encode('iso-8859-1', 'replace')
         except:


### PR DESCRIPTION
Ticket:
 https://mobilevikings-poland.atlassian.net/browse/PPYZ-280

- Added django-admin-rangefilter==0.13.2
- Modify SMSAdmin by adding DateRangeFilterBuilder for sent field
- Remove from SMSAdmin `date_hierarchy`
- Fix issue with missing opening quote in `smsgateway/backends/kpnbe.py`